### PR TITLE
Use StringBuilder instead of string

### DIFF
--- a/CsCodeGenerator.Tests/WriteTests.cs
+++ b/CsCodeGenerator.Tests/WriteTests.cs
@@ -706,7 +706,7 @@ namespace CsCodeGenerator.Tests
             return text;
         }
 
-        private List<string> ReadFileFromDisk(string path)
+        private static List<string> ReadFileFromDisk(string path)
         {
             throw new NotImplementedException();
         }

--- a/CsCodeGenerator.Tests/WriteTests.cs
+++ b/CsCodeGenerator.Tests/WriteTests.cs
@@ -39,7 +39,7 @@ namespace CsCodeGenerator.Tests
                 "protected DateTime field4;",
                 "    /// <summary>",
                 "    // Remark: List used for Ids.",
-                "    /// <summary>",
+                "    /// </summary>",
                 "    protected List<Guid> field5;"
             };
             string text = GetText(lines);
@@ -84,7 +84,7 @@ namespace CsCodeGenerator.Tests
                 "        public DateTime Property4 { get; set; }",
                 "        /// <summary>",
                 "        // Remark: Manual implemented Property.",
-                "        /// <summary>",
+                "        /// </summary>",
                 "        public List<Guid> Property5",
                 "        {",
                 "            get { return field5; }",
@@ -173,7 +173,7 @@ namespace CsCodeGenerator.Tests
                 "",
                 "        /// <summary>",
                 "        // Some Comment",
-                "        /// <summary>",
+                "        /// </summary>",
                 "        public class MyNestedClass",
                 "        {",
                 "            public MyNestedClass() { }",
@@ -491,7 +491,7 @@ namespace CsCodeGenerator.Tests
                 "",
                 "        /// <summary>",
                 "        // example of 2 KeyWords(new and virtual), usually here would be just virtual",
-                "        /// <summary>",
+                "        /// </summary>",
                 "        public new virtual string ToString()",
                 "        {",
                 "            return $\"({Real:0.00}, {Imaginary:0.00})\";",

--- a/CsCodeGenerator/ClassModel.cs
+++ b/CsCodeGenerator/ClassModel.cs
@@ -52,35 +52,36 @@ namespace CsCodeGenerator
         // Setting it automaticaly and propagating could be done if the parent sets the child's parent reference (to itself) when the child is added/assigned to a parent. Parent setter is internal.
         //   http://softwareengineering.stackexchange.com/questions/261453/what-is-the-best-way-to-initialize-a-childs-reference-to-its-parent
 
-        public override string ToString()
+        protected override void BuildStringInternal()
         {
-            string result = base.ToString();
-            result += (BaseClass != null || Interfaces?.Count > 0) ? $" : " : "";
-            result += BaseClass ?? "";
-            result += (BaseClass != null && Interfaces?.Count > 0) ? $", " : "";
-            result += Interfaces?.Count > 0 ? string.Join(", ", Interfaces) : "";
-            result += Util.NewLine + Indent + "{";
+            Builder.Append((BaseClass != null || Interfaces?.Count > 0) ? $" : " : "");
+            Builder.Append(BaseClass ?? "");
+            Builder.Append((BaseClass != null && Interfaces?.Count > 0) ? $", " : "");
 
-            result += string.Join("", Fields);
+            AppendJoin(", ", Interfaces);
+
+            AppendIntent();
+            Builder.Append("{");
+
+            AppendJoin("", Fields);
 
             var visibleConstructors = Constructors.Where(a => a.IsVisible);
             bool hasFieldsBeforeConstructor = visibleConstructors.Any() && Fields.Any();
-            result += hasFieldsBeforeConstructor ? Util.NewLine : "";
-            result += string.Join(Util.NewLine, visibleConstructors);
+            Builder.Append(hasFieldsBeforeConstructor ? Util.NewLine : "");
+            AppendJoin(Util.NewLine, visibleConstructors);
             bool hasMembersAfterConstructor = (visibleConstructors.Any() || Fields.Any()) && (Properties.Any() || Methods.Any());
-            result += hasMembersAfterConstructor ? Util.NewLine : "";
+            Builder.Append(hasMembersAfterConstructor ? Util.NewLine : "");
 
-            result += string.Join(HasPropertiesSpacing ? Util.NewLine : "", Properties);
+            AppendJoin(HasPropertiesSpacing ? Util.NewLine : "", Properties);
 
             bool hasPropertiesAndMethods = Properties.Count > 0 && Methods.Count > 0;
-            result += hasMembersAfterConstructor ? Util.NewLine : "";
-            result += string.Join(Util.NewLine, Methods);
-            
-            result += NestedClasses.Count > 0 ? Util.NewLine : "";
-            result += string.Join(Util.NewLine, NestedClasses);
+            Builder.Append(hasMembersAfterConstructor ? Util.NewLine : "");
+            AppendJoin(Util.NewLine, Methods);
 
-            result += Util.NewLine + Indent + "}";
-            return result;
+            Builder.Append(NestedClasses.Count > 0 ? Util.NewLine : "");
+            AppendJoin(Util.NewLine, NestedClasses);
+
+            Builder.Append(Util.NewLine + Indent + "}");
         }
     }
 }

--- a/CsCodeGenerator/EnumModel.cs
+++ b/CsCodeGenerator/EnumModel.cs
@@ -21,15 +21,18 @@ namespace CsCodeGenerator
 
         public List<EnumValue> EnumValues { get; set; } = new List<EnumValue>();
 
-        public override string ToString()
-        {
-            string result = base.ToString();
-            result += Util.NewLine + Indent + "{";
 
-            result += EnumValues.Count > 0 ? Util.NewLine : "";
-            result += string.Join("," + Util.NewLine, EnumValues);
-            result += Util.NewLine + Indent + "}";
-            return result;
+        protected override void BuildStringInternal()
+        {
+            AppendIntent();
+            Builder.Append("{");
+
+
+            Builder.Append(EnumValues.Count > 0 ? Util.NewLine : "");
+            AppendJoin("," + Util.NewLine, EnumValues);
+
+            AppendIntent();
+            Builder.Append("}");
         }
     }
 

--- a/CsCodeGenerator/Enums/CommentTag.cs
+++ b/CsCodeGenerator/Enums/CommentTag.cs
@@ -1,0 +1,7 @@
+﻿namespace CsCodeGenerator.Enums
+{
+    public enum CommentTag
+    {
+        Summary
+    }
+}

--- a/CsCodeGenerator/Field.cs
+++ b/CsCodeGenerator/Field.cs
@@ -12,7 +12,6 @@ namespace CsCodeGenerator
 
         public override AccessModifier AccessModifier { get; set; } = AccessModifier.Protected;
 
-        public virtual string Body { get; }
 
         public virtual string DefaultValue { get; set; }
         protected string DefaultValueFormated => DefaultValue != null ? " = " + DefaultValue : "";
@@ -21,6 +20,17 @@ namespace CsCodeGenerator
 
         protected virtual string Ending { get; } = ";";
 
-        public override string ToString() => base.ToString() + Body + DefaultValueFormated + Ending;
+        protected virtual void BuildBody()
+        {
+
+        }
+
+        protected override void BuildStringInternal()
+        {
+
+            BuildBody();
+            Builder.Append(DefaultValueFormated);
+            Builder.Append(Ending);
+        }
     }
 }

--- a/CsCodeGenerator/FileModel.cs
+++ b/CsCodeGenerator/FileModel.cs
@@ -2,7 +2,7 @@
 
 namespace CsCodeGenerator
 {
-    public class FileModel
+    public class FileModel : Serialiazble
     {
         public FileModel() { }
         public FileModel(string name)
@@ -34,16 +34,28 @@ namespace CsCodeGenerator
 
         public override string ToString()
         {
+            Builder.Clear();
+
+
             string usingText = UsingDirectives.Count > 0 ? Util.Using + " " : "";
-            string result = usingText + string.Join(Util.NewLine + usingText, UsingDirectives);
-            result += Util.NewLineDouble + Util.Namespace + " " + Namespace;
-            result += Util.NewLine + "{";
-            result += string.Join(Util.NewLine, Enums);
-            result += (Enums.Count > 0 && Classes.Count > 0) ? Util.NewLine : "";
-            result += string.Join(Util.NewLine, Classes);
-            result += Util.NewLine + "}";
-            result += Util.NewLine;
-            return result;
+            Builder.Append(usingText);
+
+            AppendJoin(Util.NewLine + usingText, UsingDirectives);
+
+            Builder.Append(Util.NewLineDouble).Append(Util.Namespace).Append(" ").Append(Namespace);
+            Builder.Append(Util.NewLine).Append("{");
+
+
+            AppendJoin(Util.NewLine, Enums);
+            Builder.Append((Enums.Count > 0 && Classes.Count > 0) ? Util.NewLine : "");
+
+            AppendJoin(Util.NewLine, Classes);
+
+
+            Builder.Append(Util.NewLine + "}");
+            Builder.Append(Util.NewLine);
+
+            return Builder.ToString();
         }
     }
 }

--- a/CsCodeGenerator/InterfaceModel.cs
+++ b/CsCodeGenerator/InterfaceModel.cs
@@ -23,20 +23,20 @@ namespace CsCodeGenerator
 
         public virtual List<Method> Methods { get; set; } = new List<Method>();
 
-        public override string ToString()
+        protected override void BuildStringInternal()
         {
-            string result = base.ToString();
-            result += Util.NewLine + Indent + "{";
+            AppendIntent();
+            Builder.Append("{");
 
-            result += string.Join("", Properties);
+            AppendJoin("", Properties);
             bool hasPropertiesAndMethods = Properties.Count > 0 && Methods.Count > 0;
-            result += hasPropertiesAndMethods ? Util.NewLine : "";
-            result += string.Join(Util.NewLine, Methods);
+            Builder.Append(hasPropertiesAndMethods? Util.NewLine : "");
+            AppendJoin(Util.NewLine, Methods);
 
-            result += Util.NewLine + Indent + "}";
-            result = result.Replace(AccessModifier.Public.ToTextLower() + " ", "");
-            result = result.Replace("\r\n        {\r\n        }", ";");
-            return result;
+            Builder.Append(Util.NewLine + Indent + "}");
+
+            Builder.Replace(AccessModifier.Public.ToTextLower() + " ", "");
+            Builder.Replace("\r\n        {\r\n        }", ";");
         }
     }
 }

--- a/CsCodeGenerator/Method.cs
+++ b/CsCodeGenerator/Method.cs
@@ -30,18 +30,23 @@ namespace CsCodeGenerator
 
         public override string Signature => base.Signature + Parameters.ToStringList();
 
-        public override string ToString()
+        protected override void BuildStringInternal()
         {
-            var xx = IndentSize;
+
             if (!IsVisible)
-                return "";
-            string result = base.ToString() + BaseParametersFormated;
+            {
+                return;
+            }
+
+            Builder.Append(BaseParametersFormated);
+
             string bracesPrefix = BracesInNewLine ? (Util.NewLine + Indent) : " ";
             string curentIndent = Util.NewLine + Indent + CsGenerator.IndentSingle;
-            result += bracesPrefix + "{";
-            result += BodyLines.Count == 0 ? "" : (BracesInNewLine ? curentIndent : " ") + string.Join(curentIndent, BodyLines);
-            result += bracesPrefix + "}";
-            return result;
+
+            Builder.Append(bracesPrefix).Append("{");
+            Builder.Append(BodyLines.Count == 0 ? "" : (BracesInNewLine ? curentIndent : " "));
+            AppendJoin(curentIndent, BodyLines);
+            Builder.Append(bracesPrefix).Append("}");
         }
     }
 }

--- a/CsCodeGenerator/Parameter.cs
+++ b/CsCodeGenerator/Parameter.cs
@@ -1,9 +1,10 @@
 ﻿using CsCodeGenerator.Enums;
 using System.Collections.Generic;
+using System.Text;
 
 namespace CsCodeGenerator
 {
-    public class Parameter
+    public class Parameter : Serialiazble
     {
         public Parameter() { }
 
@@ -48,7 +49,13 @@ namespace CsCodeGenerator
 
         public string NameValueFormated => (string.IsNullOrEmpty(Name) || string.IsNullOrEmpty(Value)) ? Name + Value : Name + " = " + Value;
 
-        public override string ToString() => KeyWordFormated + DataTypeFormated + NameValueFormated;
+        public override string ToString()
+        {
+            Builder.Clear();
+            Builder.Append(KeyWordFormated).Append(DataTypeFormated).Append(NameValueFormated);
+            return Builder.ToString();
+        }
+
     }
 
     public static class ParameterExtensions

--- a/CsCodeGenerator/Property.cs
+++ b/CsCodeGenerator/Property.cs
@@ -24,39 +24,42 @@ namespace CsCodeGenerator
 
         protected override string Ending => DefaultValue != null ? ";" : "";
 
-        public override string Body
+        protected override void BuildBody()
         {
-            get
+            base.BuildBody();
+
+            if (IsAutoImplemented && SetterBody == null)
             {
-                string result = "";
-                if (IsAutoImplemented && SetterBody == null)
+                if (IsGetOnly)
                 {
-                    if (IsGetOnly)
-                    {
-                        if(GetterBody != null)
-                            result += " => " + GetterBody + ";";
-                        else
-                            result += " { get; }";
-                    }
+                    if (GetterBody != null)
+                       Builder.Append(" => ").Append(GetterBody).Append(";");
                     else
-                    {
-                        result += " { get; set; }";
-                    }
+                        Builder.Append(" { get; }");
                 }
                 else
                 {
-                    result += Util.NewLine + Indent + "{";
-                    string curentIndent = Util.NewLine + Indent + CsGenerator.IndentSingle;
-
-                    result += curentIndent + "get { return " + GetterBody + "; }";
-                    if (!IsGetOnly && SetterBody != null)
-                    {
-                        result += curentIndent + "set { " + SetterBody + "; }";
-                    }
-                    result += Util.NewLine + Indent + "}";
+                    Builder.Append(" { get; set; }");
                 }
-                return result;
-            } 
+            }
+            else
+            {
+                AppendIntent();
+                Builder.Append("{");
+
+                AppendIntent();
+                Builder.Append(CsGenerator.IndentSingle);
+                Builder.Append("get { return ").Append(GetterBody).Append("; }");
+                if (!IsGetOnly && SetterBody != null)
+                {
+                    AppendIntent();
+                    Builder.Append(CsGenerator.IndentSingle);
+                    Builder.Append("set { ").Append(SetterBody).Append("; }");
+                }
+
+                AppendIntent();
+                Builder.Append("}");
+            }
         }
     }
 }

--- a/CsCodeGenerator/Serialiazble.cs
+++ b/CsCodeGenerator/Serialiazble.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CsCodeGenerator
+{
+    public abstract class Serialiazble
+    {
+        private StringBuilder m_Builder = new StringBuilder();
+        protected StringBuilder Builder => m_Builder;
+
+        protected void AppendJoin<T>(string separator, IEnumerable<T> collection)
+        {
+            using (var en = collection.GetEnumerator())
+            {
+                if (!en.MoveNext())
+                {
+                    return;
+                }
+
+                var firstValue = en.Current;
+
+                if (!en.MoveNext())
+                {
+                    m_Builder.Append(firstValue);
+                    return;
+                }
+
+                m_Builder.Append(firstValue);
+
+                do
+                {
+                    m_Builder.Append(separator);
+                    m_Builder.Append(en.Current);
+                }
+                while (en.MoveNext());
+
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
string is an Immutable type in c# and concatenating multiple strings will allocate a new string which can hurt performance significantly on performance-intensive environments or a CLR with slow garbage collectors (Unity, Mono).

I replaced all string usages with `StringBuilder `and only left a few small cases to refactor later. 
 